### PR TITLE
Add ability for compilation to fail, but still install Dragonfly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 import os
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+
 from numpy.distutils.core import setup, Extension
 from numpy.distutils.command.build_ext import build_ext as old_build_ext
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 from numpy.distutils.fcompiler import CompilerNotFound
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,34 @@
 #!/usr/bin/env python
 import os
 from numpy.distutils.core import setup, Extension
+from numpy.distutils.command.build_ext import build_ext as old_build_ext
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+from numpy.distutils.fcompiler import CompilerNotFound
+
+
+class BuildFailed(Exception):
+    pass
+
+
+def construct_build_ext(build_ext):
+    # This class allows extension building to fail.
+    # https://stackoverflow.com/questions/41778153/
+    ext_errors = (CCompilerError, DistutilsExecError,
+                  DistutilsPlatformError, IOError)
+    class WrappedBuildExt(build_ext):
+        def run(self):
+            try:
+                build_ext.run(self)
+            except (DistutilsPlatformError, CompilerNotFound) as x:
+                raise BuildFailed(x)
+
+        def build_extension(self, ext):
+            try:
+                build_ext.build_extension(self, ext)
+            except ext_errors as x:
+                raise BuildFailed(x)
+    return WrappedBuildExt
+
 
 with open('README.md', 'r') as f:
     LONG_DESCRIPTION = f.read()
@@ -11,7 +39,7 @@ direct_paths = [os.path.join('dragonfly', 'utils', 'direct_fortran', x) for x in
 ext1 = Extension(name='dragonfly.utils.direct_fortran.direct',
                  sources=direct_paths)
 
-setup(
+setup_options = dict(
     name='dragonfly',
     long_description=LONG_DESCRIPTION,
     url='https://github.com/dragonfly/dragonfly/',
@@ -32,6 +60,18 @@ setup(
                     "Intended Audience :: Science/Research",
                     "License :: OSI Approved :: MIT License",
     ],
-    ext_modules=[ext1],
 )
 
+try:
+    # Try building the Fortran extension.
+    setup(
+        ext_modules=[ext1],
+        cmdclass={"build_ext": construct_build_ext(old_build_ext)},
+        **setup_options
+    )
+except BuildFailed:
+    print("")
+    print("*" * 80)
+    print("Fortran compilation failed. Falling back on pure Python version.")
+    print("*" * 80)
+    setup(**setup_options)


### PR DESCRIPTION
A quick test of the changes made here can be done by running:
`python setup.py build --fcompiler $COMPILER`
where $COMPILER is a compiler from numpy's accepted list of Fortran compilers, but it not is not installed on your system. I use `pg` for example. This should give a message that the compilation failed, but then the build will proceed.

If you are on a system without any Fortran compiler, you can also test this by running
`python setup.py bdist`
This should produce a similar message as before, and build the built distribution.

Finally, to confirm that it still works as expected, running any of the other normal install procedures should work if a Fortran compiler is installed.