### PR TITLE
Add automated testing using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ cache: pip
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
-    sudo apt-get install -y -qq python-dev gfortran build-essential;
+    sudo apt-get install -y -qq python-dev gfortran liblapack-dev libatlas-dev libblas-dev build-essential ;
     fi
 
 install:
   - pip install -U pip
   - pip install numpy
-  - pip install .
+  - pip install . -v
 
 script: 
   - bash run_all_tests.sh sanity $DIRECT_STATE $OPT_STATE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 matrix:
   exclude:
     - env: INCLUDE_FORTRAN=true
-    - os: osx
+      os: osx
 
 notifications:
   email: false
@@ -21,9 +21,11 @@ notifications:
 cache: pip
 
 before_install:
-  - sudo apt-get -qq update
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$INCLUDE_FORTRAN" == true ]]; then
-    sudo apt-get install -y -qq python-dev gfortran liblapack-dev libatlas-dev libblas-dev build-essential
+    sudo apt-get install -y -qq python-dev gfortran build-essential;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INCLUDE_FORTRAN" == true ]]; then
+    brew install gfortran;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,19 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
     sudo apt-get install -y -qq python-dev gfortran build-essential ;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-    brew install openssl readline
-    brew outdated pyenv || brew upgrade pyenv
-    brew install pyenv-virtualenv
-    pyenv install $PYTHON
-    export PYENV_VERSION=$PYTHON
-    export PATH="/Users/travis/.pyenv/shims:${PATH}"
-    pyenv-virtualenv venv
-    source venv/bin/activate
-    python --version
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew update ;
+    brew install openssl readline ;
+    brew outdated pyenv || brew upgrade pyenv ;
+    brew install pyenv-virtualenv ;
+    pyenv install $PYTHON ;
+    export PYENV_VERSION=$PYTHON ;
+    export PATH="/Users/travis/.pyenv/shims:${PATH}" ;
+    pyenv-virtualenv venv ;
+    source venv/bin/activate ;
+    python --version ;
     if [[ "$DIRECT_STATE == "direct" ]]; then
-    brew install gfortran
+    brew install gfortran ;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,13 @@ matrix:
 notifications:
   email: false
 
-cache: pip
+before_cache:
+  - brew cleanup
+
+cache:
+  - pip
+  directories:
+    - $HOME/Library/Caches/Homebrew
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: python
+os:
+  - linux
+  - osx
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+env:
+  - INCLUDE_FORTRAN=false
+  - INCLUDE_FORTRAN=true
+
+matrix:
+  exclude:
+    - env: INCLUDE_FORTRAN=true
+    - os: osx
+
+notifications:
+  email: false
+
+cache: pip
+
+before_install:
+  - sudo apt-get -qq update
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$INCLUDE_FORTRAN" == true ]]; then
+    sudo apt-get install -y -qq python-dev gfortran liblapack-dev libatlas-dev libblas-dev build-essential
+    fi
+
+install:
+  - pip install -U pip
+  - pip install numpy
+  - pip install .
+
+script: 
+  - bash run_all_tests.sh sanity

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,18 @@ env:
   - DIRECT_STATE=-direct OPT_STATE=-optimal
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
+matrix:
+  include:
+    - os: osx
+      language: generic
+      env: PYTHON=2.7.12 DIRECT_STATE=direct OPT_STATE=-optimal
+#    - os: osx
+#      language: generic
+#      env: PYTHON=3.5.6
+#    - os: osx
+#      language: generic
+#      env: PYTHON=3.6.8
+
 notifications:
   email: false
 
@@ -17,6 +29,20 @@ cache: pip
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
     sudo apt-get install -y -qq python-dev gfortran build-essential ;
+    fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew update
+    brew install openssl readline
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    pyenv install $PYTHON
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    pyenv-virtualenv venv
+    source venv/bin/activate
+    python --version
+    if [[ "$DIRECT_STATE == "direct" ]]; then
+    brew install gfortran
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ python:
   - "3.5"
   - "3.6"
 env:
-  #- DIRECT_STATE=-direct OPT_STATE=-optimal
+  - DIRECT_STATE=-direct OPT_STATE=-optimal
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
 notifications:
   email: false
 
-#cache: pip
+cache: pip
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
@@ -23,8 +23,6 @@ install:
   - pip install -U pip
   - pip install numpy
   - pip install -e . -v
-  - cd dragonfly/utils/direct_fortran/
-  - python -c "import direct"
 
 script: 
   - bash run_all_tests.sh sanity $DIRECT_STATE $OPT_STATE

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - INCLUDE_FORTRAN= INCLUDE_OPT=
-  - INCLUDE_FORTRAN=fortran INCLUDE_OPT=
+  - DIRECT_STATE=-direct OPT_STATE=-optimal
+  - DIRECT_STATE=direct OPT_STATE=-optimal
 
 notifications:
   email: false
@@ -15,7 +15,7 @@ notifications:
 cache: pip
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && ! -z "$INCLUDE_FORTRAN" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && ! "$DIRECT_STATE" == "direct" ]]; then
     sudo apt-get install -y -qq python-dev gfortran build-essential;
     fi
 
@@ -25,4 +25,4 @@ install:
   - pip install .
 
 script: 
-  - bash run_all_tests.sh sanity $INCLUDE_FORTRAN $INCLUDE_OPT
+  - bash run_all_tests.sh sanity $DIRECT_STATE $OPT_STATE

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: python
 os:
   - linux
-  - osx
 python:
   - "2.7"
   - "3.5"
   - "3.6"
 env:
-  - INCLUDE_FORTRAN=false
-  - INCLUDE_FORTRAN=true
-
-matrix:
-  exclude:
-    - env: INCLUDE_FORTRAN=true
-      os: osx
+  - INCLUDE_FORTRAN= INCLUDE_OPT=
+  - INCLUDE_FORTRAN=fortran INCLUDE_OPT=
 
 notifications:
   email: false
@@ -21,11 +15,8 @@ notifications:
 cache: pip
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$INCLUDE_FORTRAN" == true ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && ! -z "$INCLUDE_FORTRAN" ]]; then
     sudo apt-get install -y -qq python-dev gfortran build-essential;
-    fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$INCLUDE_FORTRAN" == true ]]; then
-    brew install gfortran;
     fi
 
 install:
@@ -34,4 +25,4 @@ install:
   - pip install .
 
 script: 
-  - bash run_all_tests.sh sanity
+  - bash run_all_tests.sh sanity $INCLUDE_FORTRAN $INCLUDE_OPT

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,34 @@ os:
   - linux
 python:
   - "2.7"
-    #  - "3.5"
-    #  - "3.6"
+  - "3.5"
+  - "3.6"
 env:
-    #  - DIRECT_STATE=-direct OPT_STATE=-optimal
+  - DIRECT_STATE=-direct OPT_STATE=-optimal
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
+
+# We have to be explicit with the OSX versions because Python is not supported by default
 matrix:
   include:
     - os: osx
       language: generic
       env: PYTHON=2.7.12 DIRECT_STATE=direct OPT_STATE=-optimal
-#    - os: osx
-#      language: generic
-#      env: PYTHON=3.5.6
-#    - os: osx
-#      language: generic
-#      env: PYTHON=3.6.8
+    - os: osx
+      language: generic
+      env: PYTHON=2.7.12 DIRECT_STATE=-direct OPT_STATE=-optimal
+    - os: osx
+      language: generic
+      env: PYTHON=3.5.6 DIRECT_STATE=direct OPT_STATE=-optimal
+    - os: osx
+      language: generic
+      env: PYTHON=3.5.6 DIRECT_STATE=-direct OPT_STATE=-optimal
+    - os: osx
+      language: generic
+      env: PYTHON=3.6.8 DIRECT_STATE=direct OPT_STATE=-optimal
+    - os: osx
+      language: generic
+      env: PYTHON=3.6.8 DIRECT_STATE=-direct OPT_STATE=-optimal
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ before_install:
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     brew update ;
-    brew install openssl readline ;
     brew outdated pyenv || brew upgrade pyenv ;
     brew install pyenv-virtualenv ;
     pyenv install $PYTHON ;
@@ -43,7 +42,7 @@ before_install:
     python --version ;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DIRECT_STATE" == "direct" ]]; then
-    brew install gfortran ;
+    brew install gcc ;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ os:
   - linux
 python:
   - "2.7"
-  - "3.5"
-  - "3.6"
+    #  - "3.5"
+    #  - "3.6"
 env:
-  - DIRECT_STATE=-direct OPT_STATE=-optimal
+    #  - DIRECT_STATE=-direct OPT_STATE=-optimal
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
 matrix:
@@ -42,7 +42,7 @@ before_install:
     source venv/bin/activate ;
     python --version ;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DIRECT_STATE == "direct" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DIRECT_STATE" == "direct" ]]; then
     brew install gfortran ;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 install:
   - pip install -U pip
   - pip install numpy
-  - pip install . -v
+  - pip install -e . -v
   - cd dragonfly/utils/direct_fortran/
   - python -c "import direct"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_install:
     pyenv-virtualenv venv ;
     source venv/bin/activate ;
     python --version ;
-    if [[ "$DIRECT_STATE == "direct" ]]; then
-    brew install gfortran ;
     fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$DIRECT_STATE == "direct" ]]; then
+    brew install gfortran ;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 cache: pip
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && ! "$DIRECT_STATE" == "direct" ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
     sudo apt-get install -y -qq python-dev gfortran build-essential;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
     if [[ "$DIRECT_STATE == "direct" ]]; then
     brew install gfortran ;
     fi
+    fi
 
 install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - DIRECT_STATE=-direct OPT_STATE=-optimal
+  #- DIRECT_STATE=-direct OPT_STATE=-optimal
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
 notifications:
   email: false
 
-cache: pip
+#cache: pip
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
@@ -23,6 +23,8 @@ install:
   - pip install -U pip
   - pip install numpy
   - pip install . -v
+  - cd dragonfly/utils/direct_fortran/
+  - python -c "import direct"
 
 script: 
   - bash run_all_tests.sh sanity $DIRECT_STATE $OPT_STATE

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache: pip
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then
-    sudo apt-get install -y -qq python-dev gfortran liblapack-dev libatlas-dev libblas-dev build-essential ;
+    sudo apt-get install -y -qq python-dev gfortran build-essential ;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,26 +10,34 @@ env:
   - DIRECT_STATE=direct OPT_STATE=-optimal
 
 
-# We have to be explicit with the OSX versions because Python is not supported by default
+# We have to be explicit with the OSX versions because Python is not supported by default.
+# The Python versions then have to be explicitly labelled with full version numbers because
+# that is what pyenv uses for the installs. The extra "python" label to fix the display in the UI.
 matrix:
   include:
     - os: osx
       language: generic
+      python: 2.7
       env: PYTHON=2.7.12 DIRECT_STATE=direct OPT_STATE=-optimal
     - os: osx
       language: generic
+      python: 2.7
       env: PYTHON=2.7.12 DIRECT_STATE=-direct OPT_STATE=-optimal
     - os: osx
       language: generic
+      python: 3.5
       env: PYTHON=3.5.6 DIRECT_STATE=direct OPT_STATE=-optimal
     - os: osx
       language: generic
+      python: 3.5
       env: PYTHON=3.5.6 DIRECT_STATE=-direct OPT_STATE=-optimal
     - os: osx
       language: generic
+      python: 3.6
       env: PYTHON=3.6.8 DIRECT_STATE=direct OPT_STATE=-optimal
     - os: osx
       language: generic
+      python: 3.6
       env: PYTHON=3.6.8 DIRECT_STATE=-direct OPT_STATE=-optimal
 
 notifications:
@@ -42,6 +50,7 @@ cache:
   pip: true
   directories:
     - $HOME/Library/Caches/Homebrew
+    - $HOME/.pyenv_cache
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" && "$DIRECT_STATE" == "direct" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_cache:
   - brew cleanup
 
 cache:
-  - pip
+  pip: true
   directories:
     - $HOME/Library/Caches/Homebrew
 

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -5,7 +5,9 @@ then
     # Try importing dragonfly and save stdout and stderr
     res=$(python -c "import dragonfly" 2>&1 | paste -sd " " - )
 
+    echo "======================"
     echo $res
+    echo "======================"
     echo
     # Default value to reduce over
     code=1
@@ -24,11 +26,7 @@ then
     done
 
     # Return nonzero exit code if any value was found
-    if [[ $code == 0 ]];
-    then
-        exit 1;
-    fi
-    exit 0;
+    exit $(($code == 0 ));
 fi
 
 for f in $(find . -name "unittest*" | grep -v ".pyc" | sed -e 's_\./__;s_/_._g;s/\.py//');

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -2,9 +2,29 @@
 
 if [[ "$1" == "sanity" ]];
 then
-    # The ! is to invert the status code for the whole line
-    ! python -c "import dragonfly" | grep -q "No module named dragonfly"
-    exit $?
+    # Try importing dragonfly and save stdout and stderr
+    res=$(python -c "import dragonfly" 2>&1)
+
+    # Default value to reduce over
+    code=1
+    # Scan over all arguments
+    for o in "$@"
+    do
+        case "$o" in
+        sanity) echo "$res" | grep "No module named dragonfly" ;;
+        direct) echo "$res" | grep "Could not import fortran direct" ;;
+        optimal) echo "$res" | grep "Could not import Python optimal transport" ;;
+        *) echo "The accepted inputs are 'sanity', 'direct', and 'optimal'." ;;
+        esac
+        code=$(( $code & $?))
+    done
+
+    # Return nonzero exit code if any value was found
+    if [[ $code == 0 ]];
+    then
+        exit 1;
+    fi
+    exit 0;
 fi
 
 for f in $(find . -name "unittest*" | grep -v ".pyc" | sed -e 's_\./__;s_/_._g;s/\.py//');

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -14,7 +14,9 @@ then
         sanity) echo "$res" | grep "No module named dragonfly" ;;
         direct) echo "$res" | grep "Could not import fortran direct" ;;
         optimal) echo "$res" | grep "Could not import Python optimal transport" ;;
-        *) echo "The accepted inputs are 'sanity', 'direct', and 'optimal'." ;;
+        -direct) echo "$res" | grep -v "Could not import fortran direct" && echo "Has direct" ;;
+        -optimal) echo "$res" | grep -v "Could not import Python optimal transport" && echo "Has optimal" ;;
+        *) echo "The accepted inputs are 'sanity', 'direct', '-direct', 'optimal' and '-optimal'." ;;
         esac
         code=$(( $code & $?))
     done

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-clear & clear
+if [[ "$1" == "sanity" ]];
+then
+    # The ! is to invert the status code for the whole line
+    ! python -c "import dragonfly" | grep -q "No module named dragonfly"
+    exit $?
+fi
+
 for f in $(find . -name "unittest*" | grep -v ".pyc" | sed -e 's_\./__;s_/_._g;s/\.py//');
 do
     python -m unittest $f;

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -5,6 +5,7 @@ then
     # Try importing dragonfly and save stdout and stderr
     res=$(python -c "import dragonfly" 2>&1)
 
+    echo $res
     # Default value to reduce over
     code=1
     # Scan over all arguments

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -3,9 +3,10 @@
 if [[ "$1" == "sanity" ]];
 then
     # Try importing dragonfly and save stdout and stderr
-    res=$(python -c "import dragonfly" 2>&1)
+    res=$(python -c "import dragonfly" 2>&1 | paste -sd " " - )
 
     echo $res
+    echo
     # Default value to reduce over
     code=1
     # Scan over all arguments


### PR DESCRIPTION
These changes add TravisCI as a system to run automated testing of different software/OS configurations for Dragonfly. Specifically, this works for testing builds for Linux and OSX with Python 2.7/3.5/3.6, with and without Fortran compilers. An example output from TravisCI can be found [here](https://travis-ci.org/crcollins/dragonfly/).

Along with this, I included a modification to the tests to allow running a sanity check without running all the tests. This allows users to run a single command to determine what parts of dragonfly are installed. Right now, it does not really have a user facing output, but this could be extended later to be a more meaningful sanity test. Right now, it just tries to import dragonfly and does some simple evaluations on stdout and stderr to determine the installation state.

Right now, the configuration on the TravisCI side is a little bit clunky due to some issues with OSX and Python, but it is not too bad. The main issue with OSX remaining is how slow it is to configure the environment before even running the tests. I tried to set up caching, but it did not seem to help at all. Right now there is a pretty stark contrast between the Linux and OSX build times (1-2 mins vs ~9 mins). This is made worse by the limit on the number of parallel OSX jobs being lower than the Linux ones.

The commit history for this process is a bit gross because of having to test on TravisCI's servers, but it should be more or less settled now. Or at least changes should be copy/paste and/or moving things around.

There is sort of the option to add Windows tests down the line, but right now support for Python seems to be really poor so it might be more of a pain than it is worth.