### PR TITLE
Bubble up error message when imports fail

### DIFF
--- a/dragonfly/utils/oper_utils.py
+++ b/dragonfly/utils/oper_utils.py
@@ -20,13 +20,13 @@ MESSAGE = 'Could not import %s. May not be required for your application. (%s)'
 try:
   import ot as py_opt_transport # Python Optimal Transport
 except ImportError as e:
-  print(MESSAGE % ('Python optimal transport library', e))
+  warn(MESSAGE % ('Python optimal transport library', e))
   py_opt_transport = None
 # Local imports
 try:
   from .direct_fortran import direct as direct_ft_wrap
 except ImportError as e:
-  print(MESSAGE % ('fortran direct library', e))
+  warn(MESSAGE % ('fortran direct library', e))
   direct_ft_wrap = None
 from .general_utils import map_to_bounds
 from .doo import DOOFunction, pdoo_wrap

--- a/dragonfly/utils/oper_utils.py
+++ b/dragonfly/utils/oper_utils.py
@@ -14,18 +14,19 @@ from datetime import datetime
 from warnings import warn
 import os
 import numpy as np
+
+MESSAGE = 'Could not import %s. May not be required for your application. (%s)'
 # Optimal Transport
 try:
   import ot as py_opt_transport # Python Optimal Transport
-except ImportError:
-  print('Could not import Python optimal transport library. May not be required for' +
-        ' your application.')
+except ImportError as e:
+  print(MESSAGE % ('Python optimal transport library', e.message))
   py_opt_transport = None
 # Local imports
 try:
   from .direct_fortran import direct as direct_ft_wrap
-except ImportError:
-  print('Could not import fortran direct library.')
+except ImportError as e:
+  print(MESSAGE % ('fortran direct library', e.message))
   direct_ft_wrap = None
 from .general_utils import map_to_bounds
 from .doo import DOOFunction, pdoo_wrap

--- a/dragonfly/utils/oper_utils.py
+++ b/dragonfly/utils/oper_utils.py
@@ -20,13 +20,13 @@ MESSAGE = 'Could not import %s. May not be required for your application. (%s)'
 try:
   import ot as py_opt_transport # Python Optimal Transport
 except ImportError as e:
-  print(MESSAGE % ('Python optimal transport library', e.message))
+  print(MESSAGE % ('Python optimal transport library', e))
   py_opt_transport = None
 # Local imports
 try:
   from .direct_fortran import direct as direct_ft_wrap
 except ImportError as e:
-  print(MESSAGE % ('fortran direct library', e.message))
+  print(MESSAGE % ('fortran direct library', e))
   direct_ft_wrap = None
 from .general_utils import map_to_bounds
 from .doo import DOOFunction, pdoo_wrap


### PR DESCRIPTION
Here is a possible fix for the issue of different error messages absorbed when catching the `ImportError`.  This just bubbles up the error message as a warning. This gives a reference point for the error, and it allows users to silence these messages easier.