### PR TITLE
Add a DiscreteEuclideanDomain

### DIFF
--- a/dragonfly/exd/cp_domain_utils.py
+++ b/dragonfly/exd/cp_domain_utils.py
@@ -17,6 +17,7 @@ from ..utils.general_utils import flatten_list_of_objects_and_iterables, \
                                 get_original_order_from_reordered_list, \
                                 transpose_list_of_lists
 from ..utils.oper_utils import random_sample_from_euclidean_domain, \
+                             random_sample_from_discrete_euclidean_domain, \
                              random_sample_from_integral_domain, \
                              random_sample_from_prod_discrete_domain
 
@@ -98,6 +99,8 @@ def load_domain_from_params(domain_params,
   general_discrete_idxs = []
   general_discrete_numeric_items_list = []
   general_discrete_numeric_idxs = []
+  discrete_euclidean_items_list = []
+  discrete_euclidean_idxs = []
   raw_name_ordering = []
   # We will need the following variables for the function caller and the kernel
   index_ordering = [] # keeps track of which index goes where in the domain
@@ -122,6 +125,13 @@ def load_domain_from_params(domain_params,
       else:
         list_of_domains.append(domains.EuclideanDomain(curr_bounds))
         index_ordering.append(idx)
+    elif param['type'] == 'discrete_euclidean':
+        if param['kernel'] == '':
+            discrete_euclidean_items_list.extend(curr_items)
+            discrete_euclidean_idxs.extend(idx)
+        else:
+            list_of_domains.append(domains.DiscreteEuclideanDomain(curr_items))
+            index_ordering.append(idx)
     elif param['type'] == 'int':
       if param['kernel'] == '':
         general_integral_bounds.extend(curr_bounds)
@@ -370,6 +380,10 @@ def sample_from_cp_domain_without_constraints(cp_domain, num_samples,
       if dom.get_type() == 'euclidean':
         curr_domain_samples = random_sample_from_euclidean_domain(dom.bounds, num_samples,
                                                                   euclidean_sample_type)
+      elif dom.get_type() == 'discrete_euclidean':
+        curr_domain_samples = random_sample_from_discrete_euclidean_domain(dom.valid_vectors, num_samples,
+                                                                           euclidean_sample_type)
+
       elif dom.get_type() == 'integral':
         curr_domain_samples = random_sample_from_integral_domain(dom.bounds, num_samples,
                                                                  integral_sample_type)

--- a/dragonfly/exd/domains.py
+++ b/dragonfly/exd/domains.py
@@ -8,6 +8,7 @@
 
 import numpy as np
 from numbers import Number
+from scipy.spatial.distance import cdist
 
 class Domain(object):
   """ Domain class. An abstract class which implements domains. """
@@ -141,6 +142,47 @@ class IntegralDomain(Domain):
   def __str__(self):
     """ Returns a string representation. """
     return 'Integral: %s'%(_get_bounds_as_str(self.bounds))
+
+
+class DiscreteEuclideanDomain(Domain):
+  """ Domain for Discrete Euclidean spaces. """
+
+  def __init__(self, valid_vectors):
+    """ Constructor. """
+    self.valid_vectors = np.array(valid_vectors)
+    self.diameter = np.linalg.norm(self.valid_vectors.max(0) - self.valid_vectors.min(0))
+    self.dim = valid_vectors.shape[1]
+    self.size = len(valid_vectors)
+    super(DiscreteEuclideanDomain, self).__init__()
+
+  def get_type(self):
+    """ Returns the type of the domain. """
+    return 'discrete_euclidean'
+
+  def get_dim(self):
+    """ Return the dimensions. """
+    return self.dim
+
+  def is_a_member(self, point):
+    """ Returns true if point is in the domain. """
+    # Naively find the nearest point in the domain
+    return cdist([point], self.valid_vectors).min() < 1e-8 * self.diameter
+
+  def members_are_equal(self, point_1, point_2):
+    """ Compares two members and returns True if they are the same. """
+    return self.compute_distance(point_1, point_2) < 1e-8 * self.diameter
+
+  @classmethod
+  def compute_distance(cls, point_1, point_2):
+    """ Computes the distance between point_1 and point_2. """
+    return np.linalg.norm(np.array(point_1) - np.array(point_2))
+
+  def __str__(self):
+    """ Returns a string representation. """
+    base_str = '%s(%d, %d)'%(self.get_type(), self.size, self.dim)
+    if self.size < 4:
+      return '%s: %s'%(base_str, self.valid_vectors)
+    return base_str
 
 
 # Discrete spaces -------------

--- a/dragonfly/gp/cartesian_product_gp.py
+++ b/dragonfly/gp/cartesian_product_gp.py
@@ -186,6 +186,8 @@ def get_default_kernel_type(domain_type):
   """ Returns default kernel type for the domain. """
   if domain_type == 'euclidean':
     return _DFLT_DOMAIN_EUC_KERNEL_TYPE
+  elif domain_type == 'disc_euclidean':
+    return _DFLT_DOMAIN_EUC_KERNEL_TYPE
   elif domain_type == 'integral':
     return _DFLT_DOMAIN_INT_KERNEL_TYPE
   elif domain_type == 'prod_discrete':
@@ -583,6 +585,7 @@ def _get_euc_int_options(dom_type, dom_prefix, options):
   dom_type_code_dic = {'euclidean': 'euc',
                        'integral': 'int',
                        'prod_discrete_numeric': 'disc_num',
+                       'discrete_euclidean': 'euc',
                       }
   def _extract_from_options(dom_type_str, property_str):
     """ Extracts the property from the dom_type. """
@@ -821,7 +824,7 @@ def _build_kernel_for_domain(domain, dom_prefix, kernel_scale, gp_cts_hps, gp_ds
       kernel_type = _get_kernel_type_from_options(dom_type, 'dom', options)
     if kernel_type == 'default':
       kernel_type = get_default_kernel_type(dom.get_type())
-    if dom_type in ['euclidean', 'integral', 'prod_discrete_numeric']:
+    if dom_type in ['euclidean', 'integral', 'prod_discrete_numeric', 'discrete_euclidean']:
       curr_kernel_hyperparams = _prep_kernel_hyperparams_for_euc_int_kernels(
                                   kernel_type, dom, dom_prefix, options)
       use_same_bw, _, esp_kernel_type, _ = \
@@ -885,7 +888,7 @@ def _prep_kernel_hyperparams_for_euc_int_kernels(kernel_type, dom, dom_prefix, o
     return euc_int_options
 
   # Call above functions with relevant arguments.
-  if dom.get_type() == 'euclidean':
+  if dom.get_type() in ['euclidean', 'discrete_euclidean']:
     euc_int_options = _get_options_for_domain('euc')
   elif dom.get_type() == 'integral':
     euc_int_options = _get_options_for_domain('int')

--- a/dragonfly/opt/cp_ga_optimiser.py
+++ b/dragonfly/opt/cp_ga_optimiser.py
@@ -42,6 +42,19 @@ def euclidean_gauss_mutation(x, bounds, sigmas=None):
   ret = _get_gauss_perturbation(x, bounds, sigmas)
   return _return_ndarray_with_type(x, ret)
 
+def discrete_euclidean_mutation(x, valid_vectors):
+  """ Makes a change depending on the vector values. """
+  # cdist requires 2d input
+  dists = cdist([x], valid_vectors)[0]
+  # Exponentiate and normalise to get the probabilities.
+  unnorm_diff_probs = np.exp(-dists)
+  sample_diff_probs = unnorm_diff_probs / unnorm_diff_probs.sum()
+  # Now draw the samples
+  idxs = np.arange(len(sample_diff_probs))
+  idx = np.random.choice(idxs, p=sample_diff_probs)
+  ret = valid_vectors[idx]
+  return _return_ndarray_with_type(x, ret)
+
 def integral_gauss_mutation(x, bounds, sigmas=None):
   """ Defines a Euclidean Mutation. """
   ret = _get_gauss_perturbation(x, bounds, sigmas)
@@ -91,6 +104,8 @@ def get_default_mutation_op(dom):
   """ Returns the default mutation operator for the domain. """
   if dom.get_type() == 'euclidean':
     return lambda x: euclidean_gauss_mutation(x, dom.bounds)
+  elif dom.get_type() == 'disc_euclidean':
+    return lambda x: discrete_euclidean_mutation(x, dom.valid_vectors)
   elif dom.get_type() == 'integral':
     return lambda x: integral_gauss_mutation(x, dom.bounds)
   elif dom.get_type() == 'discrete':

--- a/dragonfly/utils/oper_utils.py
+++ b/dragonfly/utils/oper_utils.py
@@ -325,6 +325,14 @@ def random_sample_from_euclidean_domain(bounds, num_samples, sample_type='rand')
     raise ValueError('Unknown sample_type %s.'%(sample_type))
   return list(ret)
 
+def random_sample_from_discrete_euclidean_domain(valid_vectors, num_samples, sample_type='rand'):
+  """ Samples from a Euclidean Domain. """
+  if sample_type == 'rand' or True:
+    ret = valid_vectors[np.random.randint(len(valid_vectors), size=(num_samples, )), :]
+  else:
+    raise ValueError('Unknown sample_type %s.'%(sample_type))
+  return list(ret)
+
 def random_sample_from_integral_domain(bounds, num_samples, sample_type='rand'):
   """ Samples from a Integral Domain. """
   ret = random_sample_from_euclidean_domain(bounds, num_samples, sample_type)


### PR DESCRIPTION
This is a very rough pass at adding a DiscreteEuclideanDomain. This is not currently functioning. This PR is mostly to check if I am heading in the right direction. I am very uncertain with the config code, so that is almost a pure guess.

The end goal to be able to create optimization problems like the following:
```
import numpy as np
from dragonfly.exd.domains import DiscreteEuclideanDomain
from dragonfly import maximise_function

size = 10
dim = 3
valid_points = np.random.rand(size, dim)
dom = DiscreteEuclideanDomain(valid_points)
maximise_function(lambda x: np.linalg.norm(x), dom, 10)
```

