### PR TITLE
Fix TravisCI config for Python2 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ osx-setup-steps: &osx-setup-steps
   before_install:
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
+    - brew install readline openssl xz
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ osx-setup-steps: &osx-setup-steps
   before_install:
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
-    - brew install readline openssl xz
-    - export CFLAGS="-I$(brew --prefix openssl)/include"
-    - export LDFLAGS="-L$(brew --prefix openssl)/lib"
+    - brew unlink pyenv
+    - brew install pyenv@1.2.9
+      #- brew install readline openssl xz
+      #- export CFLAGS="-I$(brew --prefix openssl)/include"
+      #- export LDFLAGS="-L$(brew --prefix openssl)/lib"
+    - brew link pyenv@1.2.9
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ osx-setup-steps: &osx-setup-steps
   language: generic  # 'language: python' is not yet supported on macOS
   before_install:
     - brew update
+    - brew unlink pyenv
     - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/922f1a6709446cb1c6cfb954651275bf4033eef8/Formula/pyenv.rb
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ osx-setup-steps: &osx-setup-steps
   language: generic  # 'language: python' is not yet supported on macOS
   before_install:
     - brew update
+    - brew outdated pyenv || brew upgrade pyenv
     - brew unlink pyenv
     - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/922f1a6709446cb1c6cfb954651275bf4033eef8/Formula/pyenv.rb
     - if [[ "$DIRECT_STATE" == "direct" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ osx-setup-steps: &osx-setup-steps
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
     - brew unlink pyenv
-    - brew install pyenv@1.2.9
+    - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/922f1a6709446cb1c6cfb954651275bf4033eef8/Formula/pyenv.rb
       #- brew install readline openssl xz
       #- export CFLAGS="-I$(brew --prefix openssl)/include"
       #- export LDFLAGS="-L$(brew --prefix openssl)/lib"
-    - brew link pyenv@1.2.9
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ osx-setup-steps: &osx-setup-steps
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
     - brew install readline openssl xz
-    - export CFLAGS="-I$(brew --prefix openssl)/include" \
-    - export LDFLAGS="-L$(brew --prefix openssl)/lib" \
+    - export CFLAGS="-I$(brew --prefix openssl)/include"
+    - export LDFLAGS="-L$(brew --prefix openssl)/lib"
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ osx-setup-steps: &osx-setup-steps
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
     - brew install readline openssl xz
-    - alias pyenv='CFLAGS="-I$(brew --prefix openssl)/include" LDFLAGS="-L$(brew --prefix openssl)/lib" pyenv'
+    - export CFLAGS="-I$(brew --prefix openssl)/include" \
+    - export LDFLAGS="-L$(brew --prefix openssl)/lib" \
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,7 @@ osx-setup-steps: &osx-setup-steps
   language: generic  # 'language: python' is not yet supported on macOS
   before_install:
     - brew update
-    - brew outdated pyenv || brew upgrade pyenv
-    - brew unlink pyenv
     - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/922f1a6709446cb1c6cfb954651275bf4033eef8/Formula/pyenv.rb
-      #- brew install readline openssl xz
-      #- export CFLAGS="-I$(brew --prefix openssl)/include"
-      #- export LDFLAGS="-L$(brew --prefix openssl)/lib"
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ osx-setup-steps: &osx-setup-steps
     - brew update
     - brew outdated pyenv || brew upgrade pyenv
     - brew install readline openssl xz
+    - alias pyenv='CFLAGS="-I$(brew --prefix openssl)/include" LDFLAGS="-L$(brew --prefix openssl)/lib" pyenv'
     - if [[ "$DIRECT_STATE" == "direct" ]]; then
       brew install gcc ;
       fi


### PR DESCRIPTION
Well, this is sort of an unfortunate fix. It appears as though something broke in pyenv when they pushed a new version a few days ago. The fix, for now at least, is a nasty hack to use the old version. This should fix #29.