### PR TITLE
Exposed API for parallel evaluations using multi-processing

### DIFF
--- a/docs/doc_main_apis.md
+++ b/docs/doc_main_apis.md
@@ -19,12 +19,16 @@ Maximises a function `func` over the domain `domain`.
 <li> `func`: The function to be maximised.   </li>
 <li> `domain`: The domain over which the function should be maximised, should be an instance  of the Domain class in [`exd/domains.py`](https://github.com/dragonfly/dragonfly/blob/master/dragonfly/exd/domains.py).  If domain is a list of the form `[[l1, u1], [l2, u2], ...]` where `li < ui`, then we create a Euclidean domain with lower bounds `li` and upper bounds `ui` along each dimension.   </li>
 <li> `max_capital`: The maximum capital (time budget or number of evaluations) available for optimisation.   </li>
- <li> `capital_type`: The type of capital. Should be one of `'num_evals'`, `'return_value'` or
-  `'realtime'`.  Default is `'num_evals'` which indicates the number of evaluations. If
-  `'realtime'`, we will use wall clock time.   </li>
 <li> `opt_method`: The method used for optimisation. Could be one of `'bo'`, `'rand'`, `'ga'`,
   `'ea'`, `'direct'`, or `'pdoo'`. Default is `'bo'`.  `'bo'`: Bayesian optimisation,
  `'ea'`/`'ga'`: Evolutionary algorithm, `'rand'`: Random search, `'direct'`: Dividing Rectangles, `'pdoo'`: PDOO.  </li>
+<li> `worker_manager`: The type of worker manager. Should be an instance of
+             [`exd.worker_manager.AbstractWorkerManager`](https://github.com/dragonfly/dragonfly/blob/master/dragonfly/exd/worker_manager.py) or a string with one of the following values: `'default'`, `'synthetic'`, `'multiprocessing'`, `'scheduling'`. </li>
+<li> `num_workers`: The number of parallel workers (i.e. number of evaluations to carry
+out in parallel). </li>
+<li> `capital_type`: The type of capital. Should be one of `'num_evals'`, `'return_value'` or
+  `'realtime'`.  Default is `'num_evals'` which indicates the number of evaluations. If
+  `'realtime'`, we will use wall clock time.   </li>
 <li> config: Either a configuration file or or parameters returned by
              [`exd.cp_domain_utils.load_config_file`](https://github.com/dragonfly/dragonfly/blob/master/dragonfly/exd/cp_domain_utils.py). `config` can be `None` only if `domain`
              is a [`EuclideanDomain`](https://github.com/dragonfly/dragonfly/blob/master/dragonfly/exd/domains.py) object. </li>

--- a/dragonfly/apis/opt.py
+++ b/dragonfly/apis/opt.py
@@ -130,9 +130,9 @@ def maximise_multifidelity_function(func, fidel_space, domain, fidel_to_opt,
   return opt_val, opt_pt, history
 
 
-def maximise_function(func, domain, max_capital,
+def maximise_function(func, domain, max_capital, opt_method='bo',
                       worker_manager='default', num_workers=1, capital_type='num_evals',
-                      opt_method='bo', config=None, options=None, reporter='default'):
+                      config=None, options=None, reporter='default'):
   """
     Maximises a function 'func' over the domain 'domain'.
     Inputs:
@@ -150,7 +150,7 @@ def maximise_function(func, domain, max_capital,
                   rand - Random search, direct: Dividing Rectangles, pdoo: PDOO
       worker_manager: Should be an instance of WorkerManager (see exd/worker_manager.py)
                       or a string with one of the following values
-                      {'default', 'synthetic', 'multiprocessing', 'schedulint'}.
+                      {'default', 'synthetic', 'multiprocessing', 'scheduling'}.
       num_workers: The number of parallel workers (i.e. number of evaluations to carry
                    out in parallel).
       capital_type: The type of capital. Should be one of 'return_value' or 'realtime'.

--- a/dragonfly/exd/exd_core.py
+++ b/dragonfly/exd/exd_core.py
@@ -214,7 +214,7 @@ class ExperimentDesigner(object):
   def _print_header(self):
     """ Print header. """
     header_str = 'Legend: <iteration_number> (<num_successful_queries>) ' + \
-                 'cap=<fraction_of_capital_spent>:: '
+                 '<fraction_of_capital_spent>):: '
     child_header_str = self._get_exd_child_header_str()
     self.reporter.writeln(header_str + child_header_str)
 

--- a/examples/nas/demo_nas.py
+++ b/examples/nas/demo_nas.py
@@ -15,7 +15,7 @@ import shutil
 from mlp_function_caller import MLPFunctionCaller
 from cnn_function_caller import CNNFunctionCaller
 from dragonfly.opt.gp_bandit import bo_from_func_caller
-from dragonfly.exd.worker_manager import RealWorkerManager
+from dragonfly.exd.worker_manager import MultiProcessingWorkerManager
 from dragonfly.utils.reporters import get_reporter
 # Visualise
 try:
@@ -106,9 +106,9 @@ def main():
     func_caller = MLPFunctionCaller(MLP_CONFIG_FILE, train_params, reporter=reporter,
                                     tmp_dir=TMP_DIR)
   # Obtain a worker manager: A worker manager (defined in opt/worker_manager.py) is used
-  # to manage (possibly) multiple workers. For a RealWorkerManager, the budget should be
-  # given in wall clock seconds.
-  worker_manager = RealWorkerManager(GPU_IDS, EXP_DIR)
+  # to manage (possibly) multiple workers. For a MultiProcessingWorkerManager,
+  # the budget should be given in wall clock seconds.
+  worker_manager = MultiProcessingWorkerManager(GPU_IDS, EXP_DIR)
 
   # Run the optimiser
   opt_val, opt_point, _ = bo_from_func_caller(func_caller, worker_manager, BUDGET,

--- a/examples/supernova/README.md
+++ b/examples/supernova/README.md
@@ -1,7 +1,11 @@
 
 An example on maximum likelihood estimation using Type Ia supernova data.
 
-You can run this demo from the command line using the following commands.
+You can run this via,
+```bash
+$ python in_code_demo.py
+```
+Or you can run this demo from the command line using the following commands.
 ```bash
 $ dragonfly-script.py --config config.json --options options_supernova.txt
 $ dragonfly-script.py --config config_mf.json --options options_supernova.txt # For multi-fidelity version

--- a/examples/supernova/in_code_demo.py
+++ b/examples/supernova/in_code_demo.py
@@ -17,9 +17,13 @@ def main():
   config = load_config(config_params)
   max_capital = 2 * 60 * 60 # Optimisation budget in seconds
 
+  # A parallel set up where we will evaluate the function in three different threads.
+  num_workers = 3
+
   # Optimise
   opt_pt, opt_val, history = maximise_function(snls_objective, config.domain,
-                               max_capital, capital_type='realtime', config=config)
+                                               max_capital, num_workers=num_workers,
+                                               capital_type='realtime', config=config)
 
 
 if __name__ == '__main__':

--- a/examples/supernova/in_code_demo.py
+++ b/examples/supernova/in_code_demo.py
@@ -3,9 +3,11 @@
   -- kandasamy@cs.cmu.edu
 """
 
-from dragonfly import load_config, maximise_function
+from dragonfly import load_config, maximise_function, maximise_multifidelity_function
 # From current directory
 from snls import objective as snls_objective
+from snls_mf import objective as snls_mf_objective
+from snls_mf import cost as snls_mf_cost
 
 
 def main():
@@ -13,17 +15,33 @@ def main():
   domain_vars = [{'name': 'hubble_constant', 'type': 'float', 'min': 60, 'max': 80},
                  {'name': 'omega_m', 'type': 'float',  'min': 0, 'max': 1},
                  {'name': 'omega_l', 'type': 'float',  'min': 0, 'max': 1}]
-  config_params = {'domain': domain_vars}
-  config = load_config(config_params)
+  fidel_vars = [{'name': 'log10_resolution', 'type': 'float', 'min': 2, 'max': 5},
+                {'name': 'num_obs_to_use', 'type': 'int',  'min': 50, 'max': 192}]
+  fidel_to_opt = [5, 192]
   max_capital = 2 * 60 * 60 # Optimisation budget in seconds
 
   # A parallel set up where we will evaluate the function in three different threads.
   num_workers = 3
 
-  # Optimise
+  # Optimise without multi-fidelity
+  config_params = {'domain': domain_vars}
+  config = load_config(config_params)
   opt_pt, opt_val, history = maximise_function(snls_objective, config.domain,
                                                max_capital, num_workers=num_workers,
                                                capital_type='realtime', config=config)
+  print(opt_pt, opt_val)
+
+  # Optimise with multi-fidelity
+  config_params = {'domain': domain_vars, 'fidel_space': fidel_vars,
+                   'fidel_to_opt': fidel_to_opt}
+  config = load_config(config_params)
+  # Optimise
+  mf_opt_pt, mf_opt_val, history = maximise_multifidelity_function(snls_mf_objective,
+                                     config.fidel_space, config.domain,
+                                     config.fidel_to_opt, snls_mf_cost,
+                                     max_capital, config=config)
+  print(mf_opt_pt, mf_opt_val)
+
 
 
 if __name__ == '__main__':

--- a/examples/synthetic/multiobjective_park/multiobjective_park.py
+++ b/examples/synthetic/multiobjective_park/multiobjective_park.py
@@ -30,7 +30,7 @@ def park1_euc(x):
   x2 = x[1]
   x3 = x[2]
   x4 = x[3]
-  ret1 = (x1/2) * (np.sqrt(1 + (x2 + x3**2)*x4/(x1**2)) - 1)
+  ret1 = (x1/2) * (np.sqrt(1 + (x2 + x3**2)*x4/(x1**2 + 0.00001)) - 1)
   ret2 = (x1 + 3*x4) * np.exp(1 + np.sin(x3))
   return min(ret1 + ret2, max_val)
 

--- a/examples/synthetic/park1_3/park1_3.py
+++ b/examples/synthetic/park1_3/park1_3.py
@@ -17,7 +17,7 @@ def park1_3_z_x(z, x):
   x2 = x[0][1] * np.sqrt(z[1])
   x3 = x[1]/100 * np.sqrt(z[2])
   x4 = (x[2] - 10)/6.0 * np.sqrt((z[0] + z[1] + z[2]) / 3.0)
-  ret1 = (x1/2) * (np.sqrt(1 + (x2 + x3**2)*x4/(x1**2)) - 1)
+  ret1 = (x1/2) * (np.sqrt(1 + (x2 + x3**2)*x4/(x1**2 + 0.00001)) - 1)
   ret2 = (x1 + 3*x4) * np.exp(1 + np.sin(x3))
   return ret1 + ret2
 


### PR DESCRIPTION
Exposed APIs for parallel evaluations in maximise_function, maximise_multifidelity_function, and multiobjective_maximise_functions.

There are also some name changes in exd/worker_manager.py, where WorkerManager has been renamed to AbstractWorkerManager and RealWorkerManager has been renamed to MultiProcessingWorkerManager (for legacy purposes, RealWorkerManager also works and has the same functionality as MultiProcessingWorkerManager).
The MultiProcessingWorkerManager spawns a new thread for each new worker, which might be problematic if there are a large number of workers. Somewhere down the line, we will need to implement a scheduler that can handle a large number of workers asynchronously without spawning new threads.