### PR TITLE
Specify prior mean

### DIFF
--- a/dragonfly/apis/api_utils.py
+++ b/dragonfly/apis/api_utils.py
@@ -282,22 +282,17 @@ def preprocess_options_for_gp_bandits(options, config, prob, converted_cp_to_euc
       # the unprocessed version.
       pass
     else:
-      # Non-multi-fidelity version
+      # Non multi-fidelity version
       if prob == 'opt':
         if config.domain.get_type() == 'euclidean' and not converted_cp_to_euclidean:
           # If a Euclidean domain was specified originally, just use unproc version.
           gpb_prior_mean_single = options.gpb_prior_mean_unproc
         else:
           # Convert to the normalised representation
-          gpb_pmf = get_processed_func_from_raw_func_for_cp_domain(
-                      options.gpb_prior_mean_unproc, config.domain,
-                      config.domain_orderings.index_ordering,
-                      config.domain_orderings.dim_ordering)
-          if config.domain.get_type() == 'euclidean' and converted_cp_to_euclidean:
-            gpb_prior_mean_single = \
-              _get_ret_func_from_proc_func_for_conv_euc_domains(gpb_pmf)
-          else:
-            gpb_prior_mean_single = gpb_pmf
+          gpb_prior_mean_single = get_processed_func_from_raw_func_for_cp_domain(
+                                    options.gpb_prior_mean_unproc, config.domain,
+                                    config.domain_orderings.index_ordering,
+                                    config.domain_orderings.dim_ordering)
         gpb_prior_mean = \
           lambda X, *args, **kwargs: np.array([gpb_prior_mean_single(x, *args, **kwargs)
                                                for x in X])
@@ -307,14 +302,8 @@ def preprocess_options_for_gp_bandits(options, config, prob, converted_cp_to_euc
           and config.domain.get_type() == 'euclidean' and not converted_cp_to_euclidean:
           gpb_prior_mean_single = options.gpb_prior_mean_unproc
         else:
-          gpb_pmf = get_processed_func_from_raw_func_for_cp_domain_fidelity(
-                      options.gpb_prior_mean_unproc, config)
-          if config.fidel_space.get_type() == 'euclidean' \
-            and config.domain.get_type() == 'euclidean' and converted_cp_to_euclidean:
-            gpb_prior_mean_single = \
-              _get_ret_func_from_proc_func_for_conv_euc_domains_mf(gpb_pmf)
-          else:
-            gpb_prior_mean_single = gpb_pmf
+          gpb_prior_mean_single = get_processed_func_from_raw_func_for_cp_domain_fidelity(
+                                    options.gpb_prior_mean_unproc, config)
         gpb_prior_mean = \
           lambda ZX, *args, **kwargs: np.array(
             [gpb_prior_mean_single(z, x, *args, **kwargs) for (z, x) in ZX])
@@ -325,7 +314,5 @@ def preprocess_options_for_gp_bandits(options, config, prob, converted_cp_to_euc
      options.gpb_prior_kernel_unproc is not None:
     raise NotImplementedError('Not Implemented custom kernels yet!')
   # Return options =======================================================================
-  print(options.gpb_prior_mean)
-  print(options.gpb_prior_mean_unproc)
   return options
 

--- a/dragonfly/exd/exd_core.py
+++ b/dragonfly/exd/exd_core.py
@@ -213,7 +213,7 @@ class ExperimentDesigner(object):
 
   def _print_header(self):
     """ Print header. """
-    header_str = 'Legend: <iteration_number> (<num_successful_queries>) ' + \
+    header_str = 'Legend: <iteration_number> (<num_successful_queries>, ' + \
                  '<fraction_of_capital_spent>):: '
     child_header_str = self._get_exd_child_header_str()
     self.reporter.writeln(header_str + child_header_str)

--- a/dragonfly/gp/cartesian_product_gp.py
+++ b/dragonfly/gp/cartesian_product_gp.py
@@ -361,8 +361,7 @@ class CPGPFitter(gp_core.GPFitter):
         domain_dist_computers[idx]
     # Create reporter and options
     reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(cartesian_product_gp_args, 'CPGP', reporter=reporter)
+    options = load_options(cartesian_product_gp_args, partial_options=options)
     # Call super constructor
     super(CPGPFitter, self).__init__(X, Y, options, reporter)
 
@@ -405,8 +404,7 @@ class CPMFGPFitter(mf_gp.MFGPFitter):
     # pylint: disable=too-many-arguments
     # Load options
     reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(cartesian_product_mf_gp_args)
+    options = load_options(cartesian_product_mf_gp_args, partial_options=options)
     # Read from config
     if config is not None:
       if isinstance(config, str):

--- a/dragonfly/gp/cartesian_product_gp.py
+++ b/dragonfly/gp/cartesian_product_gp.py
@@ -230,7 +230,7 @@ class CPGP(gp_core.GP):
   def _child_str(self):
     """ String representation of the GP. """
     if len(self.X) > 0:
-      mean_str = 'mu=%0.4f, '%(self.mean_func([self.X[0]])[0])
+      mean_str = 'mu[#0]=%0.4f, '%(self.mean_func([self.X[0]])[0])
     else:
       mean_str = ''
     return mean_str + str(self.kernel)

--- a/dragonfly/gp/euclidean_gp.py
+++ b/dragonfly/gp/euclidean_gp.py
@@ -21,7 +21,7 @@ from ..utils.option_handler import get_option_specs, load_options
 from ..utils.oper_utils import random_sample_from_discrete_domain
 from ..utils.reporters import get_reporter
 
-_DFLT_KERNEL_TYPE = 'se'
+_DFLT_KERNEL_TYPE = 'matern'
 
 # Some basic parameters for Euclidean GPs.
 basic_euc_gp_args = [ \
@@ -36,7 +36,7 @@ se_gp_args = [ \
   ]
 # Parameters for the matern kernel
 matern_gp_args = [ \
-  get_option_specs('matern_nu', False, -1.0, \
+  get_option_specs('matern_nu', False, 2.5, \
     ('Specify the nu value for the matern kernel. If negative, will fit.')),
                  ]
 # Parameters for the Polynomial kernel.

--- a/dragonfly/gp/euclidean_gp.py
+++ b/dragonfly/gp/euclidean_gp.py
@@ -210,8 +210,7 @@ class EuclideanGPFitter(gp_core.GPFitter):
     """ Constructor. """
     self.dim = len(X[0])
     reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(euclidean_gp_args, 'EuclideanGPFitter', reporter=reporter)
+    options = load_options(euclidean_gp_args, partial_options=options)
     super(EuclideanGPFitter, self).__init__(X, Y, options, reporter)
 
   def _child_set_up(self):
@@ -423,8 +422,7 @@ class EuclideanMFGPFitter(mf_gp.MFGPFitter):
   def __init__(self, ZZ, XX, YY, options=None, reporter=None):
     """ Constructor. options should either be a Namespace, a list or None. """
     reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(euclidean_mf_gp_args, 'MF-GP', reporter)
+    options = load_options(euclidean_mf_gp_args, partial_options=options)
     self.fidel_dim = len(ZZ[0])
     self.domain_dim = len(XX[0])
     self.input_dim = self.fidel_dim + self.domain_dim

--- a/dragonfly/gp/gp_core.py
+++ b/dragonfly/gp/gp_core.py
@@ -43,6 +43,9 @@ mandatory_gp_args = [ \
   get_option_specs('handle_non_psd_kernels', False, 'guaranteed_psd',
                    'How to handle kernels that are non-psd.'),
   # The mean and noise variance of the GP
+  get_option_specs('mean_func', False, None,
+                   ('The mean function. If not None, will use this instead of the' +
+                    'other options below')),
   get_option_specs('mean_func_type', False, 'tune',
                    ('Specify the type of mean function. Should be mean, median, const ',
                     'zero, or tune. If const, specifcy value in mean-func-const.')),

--- a/dragonfly/gp/gp_core.py
+++ b/dragonfly/gp/gp_core.py
@@ -310,8 +310,7 @@ class GPFitter(object):
     super(GPFitter, self).__init__()
     assert len(X) == len(Y)
     self.reporter = get_reporter(reporter)
-    if isinstance(options, list):
-      options = load_options(options, 'GP', reporter=self.reporter)
+    options = load_options(mandatory_gp_args, partial_options=options)
     self.options = options
     self.X = X
     self.Y = Y
@@ -393,6 +392,7 @@ class GPFitter(object):
 
   def _set_up_mean_and_noise_variance_bounds(self):
     """ Sets up bounds for the mean value and the noise. """
+    # 1. The prior mean for the GP.
     if not (hasattr(self.options, 'mean_func') and self.options.mean_func is not None) \
       and self.options.mean_func_type == 'tune':
       Y_std = np.sqrt(self.Y_var)

--- a/dragonfly/gp/mf_gp.py
+++ b/dragonfly/gp/mf_gp.py
@@ -9,7 +9,7 @@ from __future__ import division
 
 # Local imports
 from . import kernel as gp_kernel
-from .gp_core import GP, GPFitter
+from .gp_core import GP, GPFitter, mandatory_gp_args
 from ..utils.option_handler import load_options
 from ..utils.reporters import get_reporter
 from ..utils.ancillary_utils import get_list_of_floats_as_str
@@ -139,8 +139,7 @@ class MFGPFitter(GPFitter):
   def __init__(self, ZZ, XX, YY, options=None, reporter=None):
     """ Constructor. """
     reporter = get_reporter(reporter)
-    if isinstance(options, list):
-      options = load_options(options, 'MFGP', reporter=self.reporter)
+    options = load_options(mandatory_gp_args, partial_options=options)
     self.ZZ = ZZ
     self.XX = XX
     self.YY = YY

--- a/dragonfly/nn/nn_gp.py
+++ b/dragonfly/nn/nn_gp.py
@@ -115,8 +115,8 @@ class NNGPFitter(gp_core.GPFitter):
     self.tp_comp = tp_comp
     # get options
     reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(nn_gp_args, 'NNGPFitter', reporter=reporter)
+    options = load_options(nn_gp_args, 'NNGPFitter', reporter=reporter,
+                           partial_options=options)
     super(NNGPFitter, self).__init__(X, Y, options, reporter, *args, **kwargs)
 
   def _child_set_up(self):

--- a/dragonfly/opt/blackbox_optimiser.py
+++ b/dragonfly/opt/blackbox_optimiser.py
@@ -202,8 +202,7 @@ class OptInitialiser(BlackboxOptimiser):
   def __init__(self, func_caller, worker_manager, get_initial_qinfos=None,
                initialisation_capital=None, options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      options = load_options(blackbox_opt_args, reporter=reporter)
+    options = load_options(blackbox_opt_args, partial_options=options)
     super(OptInitialiser, self).__init__(func_caller, worker_manager, model=None,
                                          options=options, reporter=reporter)
     self.options.max_num_steps = 0

--- a/dragonfly/opt/cp_ga_optimiser.py
+++ b/dragonfly/opt/cp_ga_optimiser.py
@@ -17,7 +17,6 @@ from ..exd.exd_utils import get_cp_domain_initial_qinfos
 from .ga_optimiser import GAOptimiser, ga_opt_args
 from ..utils.general_utils import project_to_bounds
 from ..utils.option_handler import load_options
-from ..utils.reporters import get_reporter
 
 
 cpga_opt_args = ga_opt_args
@@ -135,9 +134,7 @@ class CPGAOptimiser(GAOptimiser):
   def __init__(self, func_caller, worker_manager, single_mutation_ops=None,
                single_crossover_ops=None, options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      reporter = get_reporter(reporter)
-      options = load_options(cpga_opt_args, reporter=reporter)
+    options = load_options(cpga_opt_args, partial_options=options)
     super(CPGAOptimiser, self).__init__(func_caller, worker_manager,
       mutation_op=self._mutation_op, crossover_op=self._crossover_op,
       options=options, reporter=reporter)
@@ -205,9 +202,7 @@ def cp_ga_optimiser_from_proc_args(func_caller, cp_domain, worker_manager, max_c
   """ A GA optimiser on Cartesian product space from the function caller. """
   if not isinstance(func_caller, ExperimentCaller):
     func_caller = CPFunctionCaller(func_caller, cp_domain, domain_orderings=orderings)
-  if options is None:
-    reporter = get_reporter(reporter)
-    options = load_options(cpga_opt_args, reporter=reporter)
+  options = load_options(cpga_opt_args, partial_options=options)
   options.mode = mode
   from ..exd.worker_manager import RealWorkerManager, SyntheticWorkerManager
   if isinstance(worker_manager, RealWorkerManager):

--- a/dragonfly/opt/ga_optimiser.py
+++ b/dragonfly/opt/ga_optimiser.py
@@ -40,9 +40,7 @@ class GAOptimiser(BlackboxOptimiser):
       For other arguments, see BlackboxOptimiser
     """
     # TODO: implement cross-over operation
-    if options is None:
-      reporter = get_reporter(reporter)
-      options = load_options(ga_opt_args, reporter=reporter)
+    options = load_options(ga_opt_args, partial_options=options)
     super(GAOptimiser, self).__init__(func_caller, worker_manager, model=None,
                                       options=options, reporter=reporter)
     self.mutation_op = mutation_op
@@ -181,10 +179,8 @@ def ga_optimise_from_args(func_caller, worker_manager, max_capital, mode, mutati
                           is_rand=False, crossover_op=None, options=None,
                           reporter='default'):
   """ GA optimisation from args. """
-  if options is None:
-    reporter = get_reporter(reporter)
-    options = load_options(ga_opt_args, reporter=reporter)
-    options.mode = mode
+  options = load_options(ga_opt_args, partial_options=options)
+  options.mode = mode
   optimiser_class = GARandOptimiser if is_rand else GAOptimiser
   return (optimiser_class(func_caller, worker_manager, mutation_op, crossover_op,
                           options, reporter)).optimise(max_capital)

--- a/dragonfly/opt/gp_bandit.py
+++ b/dragonfly/opt/gp_bandit.py
@@ -68,6 +68,9 @@ gp_bandit_args = [ \
   # For multi-fidelity BO
   get_option_specs('mf_strategy', False, 'boca',
                    'Which multi-fidelity strategy to use. Should be one of {boca}.'),
+  # Mean of the GP
+  get_option_specs('gpb_prior_mean', False, None,
+                   'The prior mean of the GP for the model.'),
   # The following are perhaps not so important. Some have not been implemented yet.
   get_option_specs('shrink_kernel_with_time', False, 0,
                    'If True, shrinks the kernel with time so that we don\'t get stuck.'),
@@ -390,6 +393,13 @@ class GPBandit(BlackboxOptimiser):
     """ Returns the NOn-Multi-fidelity GP Fitter. Can be overridded by a child class. """
     raise NotImplementedError('Implement in a Child class.')
 
+  def _get_options_for_gp_fitter(self, *args, **kwargs):
+    """ Returns options for the GP Fitter. """
+    # pylint: disable=unused-argument
+    gpf_options = Namespace(**vars(self.options))
+    gpf_options.mean_func = gpf_options.gpb_prior_mean
+    return gpf_options
+
   def _build_new_gp(self):
     """ Builds a GP with the data in history and stores in self.gp. """
     if hasattr(self.func_caller, 'init_gp') and self.func_caller.init_gp is not None:
@@ -551,7 +561,7 @@ class EuclideanGPBandit(GPBandit):
 
   def _get_mf_gp_fitter(self, reg_data, use_additive=False):
     """ Returns the Multi-fidelity GP Fitter. Can be overridded by a child class. """
-    options = Namespace(**vars(self.options))
+    options = self._get_options_for_gp_fitter()
     if use_additive:
       options.domain_use_additive_gp = use_additive
     if use_additive and options.domain_kernel_type == 'esp':
@@ -561,7 +571,7 @@ class EuclideanGPBandit(GPBandit):
 
   def _get_non_mf_gp_fitter(self, reg_data, use_additive=False):
     """ Returns the NOn-Multi-fidelity GP Fitter. Can be overridded by a child class. """
-    options = Namespace(**vars(self.options))
+    options = self._get_options_for_gp_fitter()
     if use_additive:
       options.use_additive_gp = use_additive
     if use_additive and options.kernel_type == 'esp':
@@ -902,6 +912,7 @@ class CPGPBandit(GPBandit):
   def _get_mf_gp_fitter(self, reg_data, use_additive=False):
     """ Returns the Multi-fidelity GP Fitter. Can be overridded by a child class. """
     # We are not maintaining a list of distances for the domain or the fidelity space.
+    gpf_options = self._get_options_for_gp_fitter()
     fs_orderings = self.func_caller.fidel_space_orderings
     return CPMFGPFitter(reg_data[0], reg_data[1], reg_data[2], config=None,
              fidel_space=self.func_caller.fidel_space,
@@ -912,15 +923,16 @@ class CPGPBandit(GPBandit):
              domain_lists_of_dists=self.domain_lists_of_dists,
              fidel_space_dist_computers=None,
              domain_dist_computers=self.domain_dist_computers,
-             options=self.options, reporter=self.reporter)
+             options=gpf_options, reporter=self.reporter)
 
   def _get_non_mf_gp_fitter(self, reg_data, use_additive=False):
     """ Returns the NOn-Multi-fidelity GP Fitter. Can be overridded by a child class. """
+    gpf_options = self._get_options_for_gp_fitter()
     return CPGPFitter(reg_data[0], reg_data[1], self.func_caller.domain,
              domain_kernel_ordering=self.func_caller.domain_orderings.kernel_ordering,
              domain_lists_of_dists=self.domain_lists_of_dists,
              domain_dist_computers=self.domain_dist_computers,
-             options=self.options, reporter=self.reporter)
+             options=gpf_options, reporter=self.reporter)
 
 
 # APIs for Euclidean GP Bandit optimisation. ---------------------------------------------

--- a/dragonfly/opt/gp_bandit.py
+++ b/dragonfly/opt/gp_bandit.py
@@ -541,13 +541,11 @@ class EuclideanGPBandit(GPBandit):
   def __init__(self, func_caller, worker_manager, is_mf=False,
                options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      reporter = get_reporter(reporter)
-      if is_mf:
-        all_args = get_all_mf_euc_gp_bandit_args()
-      else:
-        all_args = get_all_euc_gp_bandit_args()
-      options = load_options(all_args, reporter=reporter)
+    if is_mf:
+      all_args = get_all_mf_euc_gp_bandit_args()
+    else:
+      all_args = get_all_euc_gp_bandit_args()
+    options = load_options(all_args, partial_options=options)
     super(EuclideanGPBandit, self).__init__(func_caller, worker_manager, is_mf=is_mf,
                                             options=options, reporter=reporter)
 
@@ -681,7 +679,7 @@ class EuclideanGPBandit(GPBandit):
         next_batch_of_eval_points = select_pt_func(batch_size, self.gp, anc_data)
       else:
         next_batch_of_eval_points = select_pt_func(batch_size, self.add_gp, anc_data)
-      qinfos = [Namespace(point=pt, 
+      qinfos = [Namespace(point=pt,
                           hp_tune_method=qinfo_hp_tune_method,
                           curr_acq=curr_acq) for pt in next_batch_of_eval_points]
     return qinfos
@@ -738,13 +736,12 @@ class CPGPBandit(GPBandit):
   def __init__(self, func_caller, worker_manager, is_mf=False,
                domain_dist_computers=None, options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      reporter = get_reporter(reporter)
-      if is_mf:
-        all_args = get_all_mf_euc_gp_bandit_args()
-      else:
-        all_args = get_all_cp_gp_bandit_args()
-      options = load_options(all_args, reporter)
+    # First load up options
+    if is_mf:
+      all_args = get_all_mf_euc_gp_bandit_args()
+    else:
+      all_args = get_all_cp_gp_bandit_args()
+    options = load_options(all_args, partial_options=options)
     self.domain_dist_computers = domain_dist_computers
     super(CPGPBandit, self).__init__(func_caller, worker_manager, is_mf=is_mf,
                                      options=options, reporter=reporter)

--- a/dragonfly/opt/multiobjective_gp_bandit.py
+++ b/dragonfly/opt/multiobjective_gp_bandit.py
@@ -437,14 +437,12 @@ class EuclideanMultiObjectiveGPBandit(MultiObjectiveGPBandit):
   def __init__(self, multi_func_caller, worker_manager, is_mf=False,
                options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      reporter = get_reporter(reporter)
-      if is_mf:
-        raise NotImplementedError("MF support for MO not implemented yet")
-        # all_args = get_all_mf_gp_bandit_args_from_gp_args(euclidean_mf_gp_args)
-      else:
-        all_args = get_all_euc_moo_gp_bandit_args()
-      options = load_options(all_args, reporter=reporter)
+    if is_mf:
+      raise NotImplementedError("MF support for MO not implemented yet")
+      # all_args = get_all_mf_gp_bandit_args_from_gp_args(euclidean_mf_gp_args)
+    else:
+      all_args = get_all_euc_moo_gp_bandit_args()
+    options = load_options(all_args, partial_options=options)
     super(EuclideanMultiObjectiveGPBandit, self).__init__(multi_func_caller,
       worker_manager, is_mf=is_mf, options=options, reporter=reporter)
 
@@ -624,13 +622,11 @@ class CPMultiObjectiveGPBandit(MultiObjectiveGPBandit):
   def __init__(self, multi_func_caller, worker_manager, is_mf=False,
                domain_dist_computers=None, options=None, reporter=None):
     """ Constructor. """
-    if options is None:
-      reporter = get_reporter(reporter)
-      if is_mf:
-        raise NotImplementedError(_NO_MF_FOR_MOGPB_ERR_MSG)
-      else:
-        all_args = get_all_cp_moo_gp_bandit_args()
-      options = load_options(all_args, reporter)
+    if is_mf:
+      raise NotImplementedError(_NO_MF_FOR_MOGPB_ERR_MSG)
+    else:
+      all_args = get_all_cp_moo_gp_bandit_args()
+    options = load_options(all_args, partial_options=options)
     self.domain_dist_computers = domain_dist_computers
     super(CPMultiObjectiveGPBandit, self).__init__(multi_func_caller, worker_manager,
                                           is_mf=is_mf, options=options, reporter=reporter)
@@ -782,8 +778,7 @@ def multiobjective_gpb_from_multi_func_caller(multi_func_caller, worker_manager,
       raise ValueError('GPBandit not implemented for domain of type %s.'%( \
                        type(multi_func_caller.domain)))
   # Load options
-  if options is None:
-    options = load_options(dflt_list_of_options, reporter=reporter)
+  options = load_options(dflt_list_of_options, partial_options=options)
   if acq is not None:
     options.acq = acq
   if mode is not None:

--- a/dragonfly/opt/multiobjective_gp_bandit.py
+++ b/dragonfly/opt/multiobjective_gp_bandit.py
@@ -47,6 +47,9 @@ multiobjective_gp_bandit_args = [
     'A weight sampler for moors.'),
   get_option_specs('moors_reference_point', False, None, \
     'Reference point for MOORS.'),
+  # Prior mean functions
+  get_option_specs('moo_gpb_prior_mean_funcs', False, None, \
+    'Prior GP mean functions for Multi-objective GP bandits.'),
 ]
 
 

--- a/dragonfly/opt/random_optimiser.py
+++ b/dragonfly/opt/random_optimiser.py
@@ -37,9 +37,7 @@ class RandomOptimiser(BlackboxOptimiser):
   # Constructor.
   def __init__(self, func_caller, worker_manager, options=None, reporter=None):
     """ Constructor. """
-    reporter = get_reporter(reporter)
-    if options is None:
-      options = load_options(random_optimiser_args, reporter=reporter)
+    options = load_options(random_optimiser_args, partial_options=options)
     super(RandomOptimiser, self).__init__(func_caller, worker_manager, model=None,
                                           options=options, reporter=reporter)
 
@@ -227,8 +225,7 @@ def random_optimiser_from_func_caller(func_caller, worker_manager, max_capital,
     raise ValueError('Random optimiser not implemented for domain of type %s.'%(
                      type(func_caller.domain)))
   # Load options and modify where necessary
-  if options is None:
-    options = load_options(dflt_list_of_options)
+  options = load_options(dflt_list_of_options, partial_options=options)
   options.mode = mode
   from ..exd.worker_manager import RealWorkerManager, SyntheticWorkerManager
   if isinstance(worker_manager, RealWorkerManager):
@@ -270,8 +267,7 @@ def mf_random_optimiser_from_func_caller(func_caller, worker_manager, max_capita
                       + 'of types (%s, %s).')%(
                      type(func_caller.domain), type(func_caller.fidel_space)))
   # Load options
-  if options is None:
-    options = load_options(dflt_list_of_options)
+  options = load_options(dflt_list_of_options, partial_options=options)
   options.mode = mode
   # Create optimiser
   optimiser = optimiser_constructor(func_caller, worker_manager, options=options,

--- a/dragonfly/utils/general_utils.py
+++ b/dragonfly/utils/general_utils.py
@@ -370,7 +370,7 @@ def get_exp_probs_from_fitness(fitness_vals, scaling_param=None, scaling_const=N
   fitness_vals = np.array(fitness_vals)
   if scaling_param is None:
     scaling_const = scaling_const if scaling_const is not None else 0.5
-    scaling_param = scaling_const * fitness_vals.std()
+    scaling_param = scaling_const * (fitness_vals.std() + 0.0001)
   mean_param = fitness_vals.mean()
   exp_probs = np.exp((fitness_vals - mean_param)/scaling_param)
   return exp_probs/exp_probs.sum()

--- a/dragonfly/utils/option_handler.py
+++ b/dragonfly/utils/option_handler.py
@@ -48,7 +48,8 @@ def _print_options(ondp, desc, reporter):
     reporter.writeln('  %s %s %s'%(key.ljust(30), is_changed_str, str(value[1])))
 
 
-def load_options(list_of_options, descr='Algorithm', reporter=None, cmd_line=False):
+def load_options(list_of_options, descr='Algorithm', reporter=None, cmd_line=False,
+                 partial_options=None):
   """ Given a list of options, this reads them from the command line and returns
       a namespace with the values.
   """
@@ -71,5 +72,14 @@ def load_options(list_of_options, descr='Algorithm', reporter=None, cmd_line=Fal
   for key in opt_names_default_parsed:
     opt_names_default_parsed[key][1] = getattr(args, key)
   _print_options(opt_names_default_parsed, descr, reporter)
+  # Now override with what is available in partial options
+  if partial_options is not None:
+    if isinstance(partial_options, dict):
+      partial_options_dict = partial_options
+    else:
+      partial_options_dict = vars(partial_options)
+    # Now override
+    for key, val in partial_options_dict.items():
+      setattr(args, key, val)
   return args
 

--- a/examples/detailed_use_cases/README.md
+++ b/examples/detailed_use_cases/README.md
@@ -1,0 +1,10 @@
+## Detailed Use Cases for Dragonfly
+
+This directory presents some examples, demonstrating some detailed use cases for
+Dragonfly.
+They include, incorporating a prior mean function, saving and loading results of
+past evaluations, and using a custom kernel.
+
+We use domains and configurations from an electrolyte design task, but use synthetic
+functions instead.
+

--- a/examples/detailed_use_cases/__init__.py
+++ b/examples/detailed_use_cases/__init__.py
@@ -1,0 +1,6 @@
+"""
+  Demos on some detailed use cases for Dragonfly. We use domains and configurations
+  from an electrolyte design task, but use synthetic functions instead.
+  -- kirthevasank
+"""
+

--- a/examples/detailed_use_cases/config_3d.json
+++ b/examples/detailed_use_cases/config_3d.json
@@ -1,0 +1,39 @@
+{
+"name": "opj_3d",
+
+"domain" : {
+
+  "LiNO3_vol" : {
+    "name":"LiNO3_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+
+  "Li2SO4_vol" : {
+    "name":"Li2SO4_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+
+  "NaClO4_vol" : {
+  "name":"NaClO4_vol",
+  "type":"discrete_numeric",
+  "items":"0:0.25:7.25"
+  }
+
+ },
+
+ "domain_constraints":{
+
+  "constraint_1":{
+    "name":"max_volume",
+    "constraint":"LiNO3_vol + Li2SO4_vol + NaClO4_vol <= 7"
+  },
+
+  "constraint_2":{
+    "name":"min_volume",
+    "constraint":"LiNO3_vol + Li2SO4_vol + NaClO4_vol >= 0.25"
+  }
+
+ }
+}

--- a/examples/detailed_use_cases/config_3d_cts.json
+++ b/examples/detailed_use_cases/config_3d_cts.json
@@ -6,21 +6,21 @@
   "LiNO3_vol" : {
     "name":"LiNO3_vol",
     "type":"float",
-    "items":0,
+    "min":0,
     "max":7
   },
 
   "Li2SO4_vol" : {
     "name":"Li2SO4_vol",
     "type":"float",
-    "items":0,
+    "min":0,
     "max":7
   },
 
   "NaClO4_vol" : {
     "name":"NaClO4_vol",
     "type":"float",
-    "items":0,
+    "min":0,
     "max":7
   }
 

--- a/examples/detailed_use_cases/config_3d_cts.json
+++ b/examples/detailed_use_cases/config_3d_cts.json
@@ -1,0 +1,28 @@
+{
+"name": "obj_3d",
+
+"domain" : {
+
+  "LiNO3_vol" : {
+    "name":"LiNO3_vol",
+    "type":"float",
+    "items":0,
+    "max":7
+  },
+
+  "Li2SO4_vol" : {
+    "name":"Li2SO4_vol",
+    "type":"float",
+    "items":0,
+    "max":7
+  },
+
+  "NaClO4_vol" : {
+    "name":"NaClO4_vol",
+    "type":"float",
+    "items":0,
+    "max":7
+  }
+
+ }
+}

--- a/examples/detailed_use_cases/config_3d_mf.json
+++ b/examples/detailed_use_cases/config_3d_mf.json
@@ -1,0 +1,51 @@
+{
+"name": "opt_mf_3d",
+
+"domain" : {
+
+  "LiNO3_vol" : {
+    "name":"LiNO3_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+
+  "Li2SO4_vol" : {
+    "name":"Li2SO4_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+
+  "NaClO4_vol" : {
+  "name":"NaClO4_vol",
+  "type":"discrete_numeric",
+  "items":"0:0.25:7.25"
+  }
+
+ },
+
+"domain_constraints":{
+
+  "constraint_1":{
+    "name":"max_volume",
+    "constraint":"LiNO3_vol + Li2SO4_vol + NaClO4_vol <= 7"
+  },
+
+  "constraint_2":{
+    "name":"min_volume",
+    "constraint":"LiNO3_vol + Li2SO4_vol + NaClO4_vol >= 0.25"
+  }
+
+ },
+
+"fidel_space" : {
+  "mixing_time": {
+    "name":"mixing_time",
+    "type":"float",
+    "min":60,
+    "max":180
+  }
+ },
+
+"fidel_to_opt":[180]
+
+}

--- a/examples/detailed_use_cases/config_5d.json
+++ b/examples/detailed_use_cases/config_5d.json
@@ -1,0 +1,43 @@
+{
+"name": "obj_5d",
+
+"domain" : {
+  "Na2SO4_vol" : {
+    "name":"Na2SO4_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+  "NaNO3_vol" : {
+    "name":"NaNO3_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+  "LiNO3_vol" : {
+    "name":"LiNO3_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+  "Li2SO4_vol" : {
+    "name":"Li2SO4_vol",
+    "type":"discrete_numeric",
+    "items":"0:0.25:7.25"
+  },
+  "NaClO4_vol" : {
+  	"name":"NaClO4_vol",
+  	"type":"discrete_numeric",
+  	"items":"0:0.25:7.25"
+  }
+ },
+
+ "domain_constraints":{
+  "constraint_1":{
+    "name":"max_volume",
+    "constraint":"Na2SO4_vol + NaNO3_vol + LiNO3_vol + Li2SO4_vol + NaClO4_vol <= 7"
+  },
+  "constraint_2":{
+    "name":"min_volume",
+    "constraint":"Na2SO4_vol + NaNO3_vol + LiNO3_vol + Li2SO4_vol + NaClO4_vol >= 0.25"
+  }
+ }
+
+}

--- a/examples/detailed_use_cases/in_code_demo_multi_objective.py
+++ b/examples/detailed_use_cases/in_code_demo_multi_objective.py
@@ -10,17 +10,24 @@ from dragonfly import multiobjective_maximise_functions, load_config_file
 # Local imports
 import moo_3d
 import moo_5d
+from prior_means import conductivity_prior_mean_3d, conductivity_prior_mean_5d, \
+                        conductivity_prior_mean_3d_mf
 
 
 # choose problem
 PROBLEM = '3d'
+# PROBLEM = '3d_euc'
 # PROBLEM = '5d'
 
 # chooser dict
 _CHOOSER_DICT = {
   '3d': (moo_3d.compute_objectives, moo_3d.num_objectives, 'config_3d.json'),
+  '3d_euc': (moo_3d.compute_objectives, moo_3d.num_objectives, 'config_3d_cts.json'),
   '5d': (moo_5d.compute_objectives, moo_5d.num_objectives, 'config_5d.json'),
   }
+
+USE_CONDUCTIVITY_PRIOR_MEAN = True
+# USE_CONDUCTIVITY_PRIOR_MEAN = False
 
 
 def main():
@@ -32,8 +39,22 @@ def main():
   # Specify options
   options = Namespace(
     build_new_model_every=5, # update the model every 5 iterations
-    report_results_every=6, # report progress every 6 iterations
+    report_results_every=4, # report progress every 6 iterations
+    report_model_on_each_build=True, # report the model when you build it.
     )
+
+  # Dragonfly allows specifying a mean for the GP prior - if there is prior knowledge
+  # on the rough behaviour of the function to be optimised, this is one way that
+  # information can be incorporated into the model.
+  if USE_CONDUCTIVITY_PRIOR_MEAN:
+    if PROBLEM in ['3d', '3d_euc']:
+      options.moo_gpb_prior_means_unproc = (conductivity_prior_mean_3d, None)
+    elif PROBLEM == '5d':
+      options.moo_gpb_prior_means_unproc = (conductivity_prior_mean_5d, None)
+    # The _unproc indicates that the mean function is "unprocessed". Dragonfly converts
+    # the domain specified given in the configuration to an internal order which may
+    # have reordered the variables. The _unproc tells that the function
+    # should be called in the original format.
 
   # Optimise
   max_num_evals = 60

--- a/examples/detailed_use_cases/in_code_demo_multi_objective.py
+++ b/examples/detailed_use_cases/in_code_demo_multi_objective.py
@@ -1,0 +1,48 @@
+"""
+  A demo on a multi-objective electrolyte optimisation task using various features of
+  Dragonfly.
+  -- kirthevasank
+"""
+
+from __future__ import print_function
+from argparse import Namespace
+from dragonfly import multiobjective_maximise_functions, load_config_file
+# Local imports
+import moo_3d
+import moo_5d
+
+
+# choose problem
+PROBLEM = '3d'
+# PROBLEM = '5d'
+
+# chooser dict
+_CHOOSER_DICT = {
+  '3d': (moo_3d.compute_objectives, moo_3d.num_objectives, 'config_3d.json'),
+  '5d': (moo_5d.compute_objectives, moo_5d.num_objectives, 'config_5d.json'),
+  }
+
+
+def main():
+  """ Main function. """
+  compute_objectives, num_objectives, config_file = _CHOOSER_DICT[PROBLEM]
+  config = load_config_file(config_file)
+  moo_objectives = (compute_objectives, num_objectives)
+
+  # Specify options
+  options = Namespace(
+    build_new_model_every=5, # update the model every 5 iterations
+    report_results_every=6, # report progress every 6 iterations
+    )
+
+  # Optimise
+  max_num_evals = 60
+  pareto_opt_pts, pareto_opt_vals, history = multiobjective_maximise_functions(
+    moo_objectives, config.domain, max_num_evals, config=config, options=options)
+  print(pareto_opt_pts)
+  print(pareto_opt_vals)
+
+
+if __name__ == '__main__':
+  main()
+

--- a/examples/detailed_use_cases/in_code_demo_single_objective.py
+++ b/examples/detailed_use_cases/in_code_demo_single_objective.py
@@ -15,9 +15,10 @@ from prior_means import conductivity_prior_mean_3d, conductivity_prior_mean_5d, 
 
 
 # choose problem
-# PROBLEM = '3d'
-PROBLEM = '3d_mf'
-# PROBLEM = '5d'
+# PROBLEM = '3d'      # Optimisation problem with 3 variables
+# PROBLEM = '3d_mf'   # Optimisation problem with 3 variables and 1 fidelity variable
+# PROBLEM = '3d_euc'  # Optimisation problem with 3 variables all of which are continuous
+PROBLEM = '5d'      # Optimisation problem with 5 variables
 
 USE_CONDUCTIVITY_PRIOR_MEAN = True
 # USE_CONDUCTIVITY_PRIOR_MEAN = False
@@ -25,6 +26,7 @@ USE_CONDUCTIVITY_PRIOR_MEAN = True
 # chooser dict
 _CHOOSER_DICT = {
   '3d': (obj_3d.objective, 'config_3d.json', None),
+  '3d_euc': (obj_3d.objective, 'config_3d_cts.json', None),
   '3d_mf': (obj_3d_mf.objective, 'config_3d_mf.json', obj_3d_mf.cost),
   '5d': (obj_5d.objective, 'config_5d.json', None),
   }
@@ -47,7 +49,7 @@ def main():
   # on the rough behaviour of the function to be optimised, this is one way that
   # information can be incorporated into the model.
   if USE_CONDUCTIVITY_PRIOR_MEAN:
-    if PROBLEM == '3d':
+    if PROBLEM in ['3d', '3d_euc']:
       options.gpb_prior_mean_unproc = conductivity_prior_mean_3d
     elif PROBLEM == '3d_mf':
       options.gpb_prior_mean_unproc = conductivity_prior_mean_3d_mf
@@ -60,7 +62,7 @@ def main():
 
   # Optimise
   max_capital = 60
-  if PROBLEM in ['3d', '5d']:
+  if PROBLEM in ['3d', '3d_euc', '5d']:
     opt_pt, opt_val, history = maximise_function(objective, config.domain, max_capital,
                                                  config=config, options=options)
   else:

--- a/examples/detailed_use_cases/in_code_demo_single_objective.py
+++ b/examples/detailed_use_cases/in_code_demo_single_objective.py
@@ -15,10 +15,10 @@ from prior_means import conductivity_prior_mean_3d, conductivity_prior_mean_5d, 
 
 
 # choose problem
-# PROBLEM = '3d'      # Optimisation problem with 3 variables
+PROBLEM = '3d'      # Optimisation problem with 3 variables
 # PROBLEM = '3d_mf'   # Optimisation problem with 3 variables and 1 fidelity variable
 # PROBLEM = '3d_euc'  # Optimisation problem with 3 variables all of which are continuous
-PROBLEM = '5d'      # Optimisation problem with 5 variables
+# PROBLEM = '5d'      # Optimisation problem with 5 variables
 
 USE_CONDUCTIVITY_PRIOR_MEAN = True
 # USE_CONDUCTIVITY_PRIOR_MEAN = False
@@ -41,7 +41,7 @@ def main():
   # Specify options
   options = Namespace(
     build_new_model_every=5, # update the model every 5 iterations
-    report_results_every=4, # report progress every 6 iterations
+    report_results_every=4, # report progress every 4 iterations
     report_model_on_each_build=True, # report model when you build it.
     )
 

--- a/examples/detailed_use_cases/in_code_demo_single_objective.py
+++ b/examples/detailed_use_cases/in_code_demo_single_objective.py
@@ -1,0 +1,77 @@
+"""
+  A demo on an electrolyte optimisation task using various features of Dragonfly.
+  -- kirthevasank
+"""
+
+from __future__ import print_function
+from argparse import Namespace
+from dragonfly import load_config_file, maximise_function, maximise_multifidelity_function
+# Local imports
+import obj_3d
+import obj_3d_mf
+import obj_5d
+from prior_means import conductivity_prior_mean_3d, conductivity_prior_mean_5d, \
+                        conductivity_prior_mean_3d_mf
+
+
+# choose problem
+# PROBLEM = '3d'
+PROBLEM = '3d_mf'
+# PROBLEM = '5d'
+
+USE_CONDUCTIVITY_PRIOR_MEAN = True
+# USE_CONDUCTIVITY_PRIOR_MEAN = False
+
+# chooser dict
+_CHOOSER_DICT = {
+  '3d': (obj_3d.objective, 'config_3d.json', None),
+  '3d_mf': (obj_3d_mf.objective, 'config_3d_mf.json', obj_3d_mf.cost),
+  '5d': (obj_5d.objective, 'config_5d.json', None),
+  }
+
+
+def main():
+  """ Main function. """
+  # Load configuration file
+  objective, config_file, mf_cost = _CHOOSER_DICT[PROBLEM]
+  config = load_config_file(config_file)
+
+  # Specify options
+  options = Namespace(
+    build_new_model_every=5, # update the model every 5 iterations
+    report_results_every=4, # report progress every 6 iterations
+    report_model_on_each_build=True, # report model when you build it.
+    )
+
+  # Dragonfly allows specifying a mean for the GP prior - if there is prior knowledge
+  # on the rough behaviour of the function to be optimised, this is one way that
+  # information can be incorporated into the model.
+  if USE_CONDUCTIVITY_PRIOR_MEAN:
+    if PROBLEM == '3d':
+      options.gpb_prior_mean_unproc = conductivity_prior_mean_3d
+    elif PROBLEM == '3d_mf':
+      options.gpb_prior_mean_unproc = conductivity_prior_mean_3d_mf
+    elif PROBLEM == '5d':
+      options.gpb_prior_mean_unproc = conductivity_prior_mean_5d
+    # The _unproc indicates that the mean function is "unprocessed". Dragonfly converts
+    # the domain specified given in the configuration to an internal order which may
+    # have reordered the variables. The _unproc tells that the function
+    # should be called in the original format.
+
+  # Optimise
+  max_capital = 60
+  if PROBLEM in ['3d', '5d']:
+    opt_pt, opt_val, history = maximise_function(objective, config.domain, max_capital,
+                                                 config=config, options=options)
+  else:
+    opt_pt, opt_val, history = maximise_multifidelity_function(objective,
+                                 config.fidel_space, config.domain, config.fidel_to_opt,
+                                 mf_cost, max_capital, config=config, options=options)
+
+  print(opt_pt)
+  print(opt_val)
+
+
+if __name__ == '__main__':
+  main()
+

--- a/examples/detailed_use_cases/moo_3d.py
+++ b/examples/detailed_use_cases/moo_3d.py
@@ -1,0 +1,23 @@
+"""
+  Synthetic multi-objective function for 3D optimisation.
+  -- kirthevasank
+"""
+
+import numpy as np
+
+num_objectives = 2
+
+def compute_objectives(x):
+  """ Computes the objectives. """
+  vol1 = x[0] # LiNO3
+  vol2 = x[1] # Li2SO4
+  vol3 = x[2] # NaClO4
+  vol4 = 10 - (vol1 + vol2 + vol3) # Water
+  # Synthetic functions
+  conductivity = vol1 + 0.1 * (vol2 + vol3) ** 2 + 2.3 * vol4 * (vol1 ** 1.5)
+  voltage_window = 0.5 * (vol1 + vol2) ** 1.7 + 1.2 * (vol3 ** 0.5) * (vol1 ** 1.5)
+  # Add Gaussian noise to simulate experimental noise
+  conductivity += np.random.normal() * 0.01
+  voltage_window += np.random.normal() * 0.01
+  return [conductivity, voltage_window]
+

--- a/examples/detailed_use_cases/moo_5d.py
+++ b/examples/detailed_use_cases/moo_5d.py
@@ -1,0 +1,27 @@
+"""
+  Synthetic multi-objective function for 3D optimisation.
+  -- kirthevasank
+"""
+
+import numpy as np
+
+num_objectives = 2
+
+def compute_objectives(x):
+  """ Computes the objectives. """
+  vol1 = x[0] # Na2SO4
+  vol2 = x[1] # NaNO3
+  vol3 = x[2] # LiNO3
+  vol4 = x[3] # Li2SO4
+  vol5 = x[4] # NaClO4
+  vol6 = 10 - (vol1 + vol2 + vol3 + vol4 + vol5) # Water
+  # Synthetic functions
+  conductivity = 0.9 * (vol1 + vol5) + 0.1 * (vol2 + vol3) ** 2 + \
+                 0.8 * vol4 * vol3 + 2.1 * vol6 * (vol1 ** 1.5)
+  voltage_window = 0.5 * (vol3 + vol2) ** 1.7 + 0.9 * vol1 * vol4 + \
+                   1.2 * (vol4 ** 0.5) * (vol6 ** 1.5)
+  # Add Gaussian noise to simulate experimental noise
+  conductivity += np.random.normal() * 0.01
+  voltage_window += np.random.normal() * 0.01
+  return [conductivity, voltage_window]
+

--- a/examples/detailed_use_cases/obj_3d.py
+++ b/examples/detailed_use_cases/obj_3d.py
@@ -1,0 +1,11 @@
+"""
+  Synthetic function for 3D optimisation.
+  -- kirthevasank
+"""
+
+from moo_3d import compute_objectives as moo_objectives
+
+def objective(x):
+  """ Computes the objectives. """
+  return moo_objectives(x)[0] # Just returns conductivity
+

--- a/examples/detailed_use_cases/obj_3d_mf.py
+++ b/examples/detailed_use_cases/obj_3d_mf.py
@@ -1,0 +1,24 @@
+"""
+  Synthetic function for 3D multi-fidelity optimisation.
+  -- kirthevasank
+"""
+
+def objective(z, x):
+  """ Computes the objectives. """
+  normalised_z = (z[0] - 60.0)/ 120.0
+  vol1 = x[0] # LiNO3
+  vol2 = x[1] # Li2SO4
+  vol3 = x[2] # NaClO4
+  vol4 = 10 - (vol1 + vol2 + vol3) # Water
+  # Synthetic functions
+  conductivity = vol1 * normalised_z + \
+                 0.1 * (vol2 + vol3) ** 2 * (normalised_z ** 1.5) + \
+                 2.3 * vol4 * (vol1 ** 1.5)
+  return conductivity
+
+
+def cost(z):
+  """ Cost function. """
+  normalised_z = (z[0] - 60.0)/ 120.0
+  return 0.1 + 0.9 * normalised_z 
+

--- a/examples/detailed_use_cases/obj_5d.py
+++ b/examples/detailed_use_cases/obj_5d.py
@@ -1,0 +1,11 @@
+"""
+  Synthetic function for 5D optimisation.
+  -- kirthevasank
+"""
+
+from moo_5d import compute_objectives as moo_objectives
+
+def objective(x):
+  """ Computes the objectives. """
+  return moo_objectives(x)[0] # Just returns conductivity
+

--- a/examples/detailed_use_cases/prior_means.py
+++ b/examples/detailed_use_cases/prior_means.py
@@ -1,0 +1,48 @@
+"""
+  Prior mean functions used in the examples in this directory.
+  -- kirthevasank
+"""
+
+# We are simply collecting all the prior mean functions used in the demos here for
+# neatness. They need not be defined this way.
+
+# This is the prior mean we will use for the conductivity in the 3D example.
+# We use this in in_code_demo_multi_objective.py and in_code_demo_single_objective.py
+def conductivity_prior_mean_3d(x):
+  """ Prior mean for the conductivity. """
+  vol1 = x[0] # LiNO3
+  vol2 = x[1] # Li2SO4
+  vol3 = x[2] # NaClO4
+  vol4 = 10 - (vol1 + vol2 + vol3) # Water
+  return 0.9 * vol1 + 0.12 * (vol2 + vol3) ** 2.05 + 2.4 * vol4 * (vol1 ** 1.6)
+
+
+# Prior mean for the conductivity in the 3D example with multi-fidelity.
+# See in_code_demo_single_objective.py
+def conductivity_prior_mean_3d_mf(z, x):
+  """ Prior mean for the conductivity with multi-fidelity. """
+  normalised_z = (z[0] - 60.0)/ 120.0
+  vol1 = x[0] # LiNO3
+  vol2 = x[1] # Li2SO4
+  vol3 = x[2] # NaClO4
+  vol4 = 10 - (vol1 + vol2 + vol3) # Water
+  # Synthetic functions
+  return 0.9 * vol1 * normalised_z + \
+         0.12 * (vol2 + vol3) ** 2.005 * (normalised_z ** 1.55) + \
+         2.4 * vol4 * (vol1 ** 1.5)
+
+
+# Prior mean for the conductivity in the 5D example.
+# See in_code_demo_multi_objective.py and in_code_demo_single_objective.py
+def conductivity_prior_mean_5d(x):
+  """ Prior mean for the conductivity. """
+  vol1 = x[0] # Na2SO4
+  vol2 = x[1] # NaNO3
+  vol3 = x[2] # LiNO3
+  vol4 = x[3] # Li2SO4
+  vol5 = x[4] # NaClO4
+  vol6 = 10 - (vol1 + vol2 + vol3 + vol4 + vol5) # Water
+  # Synthetic functions
+  return 1.01 * (vol1 + vol5) + 0.15 * (vol2 + vol3) ** 2.05 + \
+         0.76 * vol4 * vol3 + 2.2 * vol6 * (vol1 ** 1.6)
+

--- a/examples/synthetic/discrete_euc/in_code_demo_1.py
+++ b/examples/synthetic/discrete_euc/in_code_demo_1.py
@@ -22,8 +22,13 @@ def main():
   config_params = {'domain': domain_vars}
   config = load_config(config_params)
   max_num_evals = 100
+
+  # specify optimisation method
+#   opt_method = 'bo' # Bayesian optimisation
+  opt_method = 'ea' # evolutionary algorithm
+#   opt_method = 'rand' # random search
   opt_pt, opt_val, history = maximise_function(objective, config.domain, max_num_evals,
-                                               config=config)
+                                               config=config, opt_method=opt_method)
   print(opt_pt, opt_val)
 
 


### PR DESCRIPTION
Incorporated functionality to specify a mean for the GP prior, both for single and multi-objective optimisation.

See examples/detailed_use_cases/in_code_demo_xxx.py for examples.