### PR TITLE
Skip evaluation errors

### DIFF
--- a/dragonfly/exd/experiment_caller.py
+++ b/dragonfly/exd/experiment_caller.py
@@ -146,14 +146,20 @@ class ExperimentCaller(object):
     """ Returns the true value from the experiment. Can be overridden by child class if
         experiment is represented differently. """
     assert self.domain.is_a_member(point)
-    return self.experiment(point)
+    try:
+      return self.experiment(point)
+    except:
+      return EVAL_ERROR_CODE
 
   def _get_true_val_from_experiment_at_fidel_point(self, fidel, point):
     """ Returns the true value from the experiment. Can be overridden by child class if
         experiment is represented differently. """
     assert self.fidel_space.is_a_member(fidel)
     assert self.domain.is_a_member(point)
-    return self.experiment(fidel, point)
+    try:
+      return self.experiment(fidel, point)
+    except:
+      return EVAL_ERROR_CODE
 
   # Single fidelity evaluations --------------------------------------------
   def eval_single(self, point, qinfo=None, noisy=True):

--- a/dragonfly/opt/multiobjective_optimiser.py
+++ b/dragonfly/opt/multiobjective_optimiser.py
@@ -15,6 +15,7 @@ import numpy as np
 # Local imports
 from ..exd.exd_core import ExperimentDesigner, exd_core_args
 from ..exd.experiment_caller import MultiFunctionCaller, FunctionCaller
+from ..exd.exd_utils import EVAL_ERROR_CODE
 from ..utils.general_utils import update_pareto_set
 
 
@@ -110,6 +111,8 @@ class MultiObjectiveOptimiser(ExperimentDesigner):
       if not query_is_at_fidel_to_opt:
         # if the fidelity queried at is not fidel_to_opt, then return
         return
+    if qinfo.val == EVAL_ERROR_CODE:
+      return
     # Optimise curr_opt_val and curr_true_opt_val
     self.curr_pareto_vals, self.curr_pareto_points = update_pareto_set(
       self.curr_pareto_vals, self.curr_pareto_points, qinfo.val, qinfo.point)

--- a/examples/synthetic/multiobjective_hartmann/config_failing.json
+++ b/examples/synthetic/multiobjective_hartmann/config_failing.json
@@ -1,0 +1,40 @@
+{
+"name": "multiobjective_hartmann_failing",
+
+"domain": {
+
+  "var_0": {
+    "name":"var_0",
+    "type":"int",
+    "min":224,
+    "max":324
+  },
+
+  "var_1": {
+    "name":"var_1",
+    "type":"float",
+    "min":0,
+    "max":10,
+    "kernel":"matern",
+    "dim":2
+  },
+
+  "var_2": {
+    "name":"var_2",
+    "type":"float",
+    "min":0,
+    "max":1,
+    "dim":1
+  },
+
+  "var_3": {
+    "name":"var_3",
+    "type":"int",
+    "min":0,
+    "max":92,
+    "dim":2
+  }
+
+ }
+}
+

--- a/examples/synthetic/multiobjective_hartmann/multiobjective_hartmann_failing.py
+++ b/examples/synthetic/multiobjective_hartmann/multiobjective_hartmann_failing.py
@@ -1,0 +1,24 @@
+"""
+  Multi-objective version of the Hartmann functions, with random failures.
+"""
+
+# pylint: disable=invalid-name
+
+try:
+  from multiobjective_hartmann import hartmann3_by_2_1, hartmann6, hartmann3_by_2_2
+except ImportError:
+  from .multiobjective_hartmann import hartmann3_by_2_1, hartmann6, hartmann3_by_2_2
+
+import random
+from dragonfly.exd.exd_utils import EVAL_ERROR_CODE
+
+random.seed(1)
+
+num_objectives = 3
+def compute_objectives(x):
+  """ Computes the objectives. """
+  if random.random() < 0.25:
+      return [hartmann3_by_2_1(x), hartmann6(x), hartmann3_by_2_2(x)]
+  else:
+      #alternatively: raise Exception()
+      return EVAL_ERROR_CODE


### PR DESCRIPTION
These are minimal fixes to handle errors in the objective function evaluation, using the EVAL_ERROR_CODE constant defined in exd_utils.py.  With these fixes, using a randomly failing objective appears to work reasonably well, provided that the acquisition optimization is random (i.e. Thompson sampling, or multiobjective optimization by MOORS).